### PR TITLE
Adding configurable endpoint to use on staging servers

### DIFF
--- a/lib/omniauth/adp_oauth2/version.rb
+++ b/lib/omniauth/adp_oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module AdpOauth2
-    VERSION = '0.0.1'
+    VERSION = '0.0.2'
   end
 end

--- a/lib/omniauth/strategies/adp_oauth2.rb
+++ b/lib/omniauth/strategies/adp_oauth2.rb
@@ -14,7 +14,7 @@ module OmniAuth
       option :authorize_options, %i(response_type client_id redirect_uri scope state)
 
       option :client_options, {
-        :site          => ENV['ADP_BASE_URL'] || 'https://accounts.adp.com',
+        :site          => ENV['ADP_AUTH_HOST'] || 'https://accounts.adp.com',
         :authorize_url => '/auth/oauth/v2/authorize',
         :token_url     => '/auth/oauth/v2/token'
       }

--- a/lib/omniauth/strategies/adp_oauth2.rb
+++ b/lib/omniauth/strategies/adp_oauth2.rb
@@ -14,7 +14,7 @@ module OmniAuth
       option :authorize_options, %i(response_type client_id redirect_uri scope state)
 
       option :client_options, {
-        :site          => 'https://accounts.adp.com',
+        :site          => ENV['ADP_BASE_URL'] || 'https://accounts.adp.com',
         :authorize_url => '/auth/oauth/v2/authorize',
         :token_url     => '/auth/oauth/v2/token'
       }


### PR DESCRIPTION
Currently this library only works with production.  This allows the library to have a configurable host with a fallback of production, making it reverse compatible.