### PR TITLE
Update the jwt gem version requirement to 2.0+

### DIFF
--- a/lib/omniauth/adp_oauth2/version.rb
+++ b/lib/omniauth/adp_oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module AdpOauth2
-    VERSION = '0.0.2'
+    VERSION = '0.0.3'
   end
 end

--- a/omniauth-adp-oauth2.gemspec
+++ b/omniauth-adp-oauth2.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'omniauth', '>= 1.1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.3.1'
-  gem.add_runtime_dependency 'jwt', '~> 1.5.2'
+  gem.add_runtime_dependency 'jwt', '>= 2.0'
   gem.add_runtime_dependency 'multi_json', '~> 1.3'
 
   # gem.add_development_dependency 'rspec', '>= 2.14.0'


### PR DESCRIPTION
This updates the `jwt` gem dependency to 2.0.  Needed to bump as it conflicts with other oauth gems in our stack (e.g. google)